### PR TITLE
typo correction in ci-build.yaml

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: pyton:3.9-slim
+    container: python:3.9-slim
     services:
       postgres:
         image: postgres:alpine


### PR DESCRIPTION
typo on "container: pyton:3.9-slim"